### PR TITLE
Add missing @ConditionalOnMissingBean annotations

### DIFF
--- a/spring-security-oauth2-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-security-oauth2-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -277,6 +277,7 @@ public class ResourceServerTokenServicesConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnMissingBean(JwtAccessTokenConverter.class)
 		public JwtAccessTokenConverter jwtTokenEnhancer() {
 			JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
 			String keyValue = this.resource.getJwt().getKeyValue();
@@ -356,6 +357,7 @@ public class ResourceServerTokenServicesConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnMissingBean(JwtAccessTokenConverter.class)
 		public JwtAccessTokenConverter accessTokenConverter() {
 			Assert.notNull(this.resource.getJwt().getKeyStore(),
 					"keyStore cannot be null");

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
@@ -279,7 +279,8 @@ public class ResourceServerTokenServicesConfigurationTests {
 	}
 
 	@Test
-	public void jwtAccessTokenConverterForKeyValueShouldBeConditionalOnMissingBean() throws Exception {
+	public void jwtAccessTokenConverterForKeyValueShouldBeConditionalOnMissingBean()
+		throws Exception {
 		TestPropertyValues.of("security.oauth2.resource.jwt.keyValue=" + PUBLIC_KEY)
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(JwtTokenStoreConfiguration.class,
@@ -289,7 +290,8 @@ public class ResourceServerTokenServicesConfigurationTests {
 	}
 
 	@Test
-	public void jwtAccessTokenConverterForKeyStoreShouldBeConditionalOnMissingBean() throws Exception {
+	public void jwtAccessTokenConverterForKeyStoreShouldBeConditionalOnMissingBean()
+		throws Exception {
 		TestPropertyValues.of("security.oauth2.resource.jwt.key-store=classpath:"
 				+ "org/springframework/boot/autoconfigure/security/oauth2/resource/keystore.jks",
 				"security.oauth2.resource.jwt.key-store-password=changeme",

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
@@ -279,6 +279,28 @@ public class ResourceServerTokenServicesConfigurationTests {
 	}
 
 	@Test
+	public void jwtAccessTokenConverterForKeyValueShouldBeConditionalOnMissingBean() throws Exception {
+		TestPropertyValues.of("security.oauth2.resource.jwt.keyValue=" + PUBLIC_KEY)
+				.applyTo(this.environment);
+		this.context = new SpringApplicationBuilder(JwtTokenStoreConfiguration.class,
+				ResourceConfiguration.class).environment(this.environment)
+						.web(WebApplicationType.NONE).run();
+		assertThat(this.context.getBeansOfType(JwtAccessTokenConverter.class)).hasSize(1);
+	}
+
+	@Test
+	public void jwtAccessTokenConverterForKeyStoreShouldBeConditionalOnMissingBean() throws Exception {
+		TestPropertyValues.of("security.oauth2.resource.jwt.key-store=classpath:"
+				+ "org/springframework/boot/autoconfigure/security/oauth2/resource/keystore.jks",
+				"security.oauth2.resource.jwt.key-store-password=changeme",
+				"security.oauth2.resource.jwt.key-alias=jwt").applyTo(this.environment);
+		this.context = new SpringApplicationBuilder(JwtTokenStoreConfiguration.class,
+				ResourceConfiguration.class).environment(this.environment)
+						.web(WebApplicationType.NONE).run();
+		assertThat(this.context.getBeansOfType(JwtAccessTokenConverter.class)).hasSize(1);
+	}
+	
+	@Test
 	public void configureWhenKeyStoreIsProvidedThenExposesJwtTokenStore() {
 		TestPropertyValues.of("security.oauth2.resource.jwt.key-store=classpath:"
 				+ "org/springframework/boot/autoconfigure/security/oauth2/resource/keystore.jks",


### PR DESCRIPTION
The jwtTokenEnhancer bean can no longer be overridden in it's current state. The proposed changes seem to be necessary as a result of the changes related to [13609](https://github.com/spring-projects/spring-boot/issues/13609) (discussed in [Spring-Boot-2.1-Release-Notes -> bean-overriding](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding).