### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -106,7 +106,7 @@ By default, `@EnableAuthorizationServer` grants a client access to client creden
 ====
 [source,bash]
 ----
-curl first-client:noonewilleverguess@localhost:8080/oauth/token -dgrant_type=client_credentials -dscope=any
+curl first_client:noonewilleverguess@localhost:8080/oauth/token -dgrant_type=client_credentials -dscope=any
 ----
 ====
 


### PR DESCRIPTION
client-id in the yaml file is first_client, but was first-client in the curl statement.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->