### PR TITLE
Change first_client to first-client

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -87,7 +87,7 @@ The following example shows how to specify a client:
 security:
   oauth2:
     client:
-      client-id: first_client
+      client-id: first-client
       client-secret: noonewilleverguess
 ----
 ====
@@ -106,7 +106,7 @@ By default, `@EnableAuthorizationServer` grants a client access to client creden
 ====
 [source,bash]
 ----
-curl first_client:noonewilleverguess@localhost:8080/oauth/token -dgrant_type=client_credentials -dscope=any
+curl first-client:noonewilleverguess@localhost:8080/oauth/token -dgrant_type=client_credentials -dscope=any
 ----
 ====
 


### PR DESCRIPTION
As I continued reading the docs, I noticed that 4 out of 6 occurrences where using first-client instead of first_client. I decided to switch them to first-client to make it consistent across the docs.

<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->