### PR TITLE
URL Cleanup

### DIFF
--- a/eclipse/spring-boot-project.setup
+++ b/eclipse/spring-boot-project.setup
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <setup:Project
     xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xmi="https://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
-    xmlns:maven="http://www.eclipse.org/oomph/setup/maven/1.0"
-    xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
-    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
-    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
-    xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
-    xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xmlns:jdt="https://www.eclipse.org/oomph/setup/jdt/1.0"
+    xmlns:maven="https://www.eclipse.org/oomph/setup/maven/1.0"
+    xmlns:predicates="https://www.eclipse.org/oomph/predicates/1.0"
+    xmlns:setup="https://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="https://www.eclipse.org/oomph/setup/p2/1.0"
+    xmlns:setup.workingsets="https://www.eclipse.org/oomph/setup/workingsets/1.0"
+    xmlns:workingsets="https://www.eclipse.org/oomph/workingsets/1.0"
+    xsi:schemaLocation="https://www.eclipse.org/oomph/setup/jdt/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore https://www.eclipse.org/oomph/setup/maven/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore https://www.eclipse.org/oomph/predicates/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore https://www.eclipse.org/oomph/setup/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore https://www.eclipse.org/oomph/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
     name="spring.boot"
     label="Spring Boot">
   <setupTask
@@ -90,19 +90,19 @@
     <requirement
         name="org.springframework.ide.eclipse.jdt.formatter.feature.feature.group"/>
     <repository
-        url="http://download.eclipse.org/technology/epp/packages/mars/R"/>
+        url="https://download.eclipse.org/technology/epp/packages/mars/R"/>
     <repository
-        url="http://download.eclipse.org/releases/mars"/>
+        url="https://download.eclipse.org/releases/mars"/>
     <repository
-        url="http://andrei.gmxhome.de/eclipse"/>
+        url="http://andrei.gmxhome.de/eclipse/"/>
     <repository
         url="https://dl.bintray.com/philwebb/m2eclipse-maveneclipse"/>
     <repository
         url="https://dl.bintray.com/philwebb/spring-eclipse-code-formatter"/>
     <repository
-        url="http://dist.springsource.com/release/TOOLS/update/e4.5"/>
+        url="https://dist.springsource.com/release/TOOLS/update/e4.5"/>
     <repository
-        url="http://download.eclipse.org/egit/github/updates/"/>
+        url="https://download.eclipse.org/egit/github/updates/"/>
     <description>
       Install the tools needed in the IDE to work with the
       source code for ${scope.project.label}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://andrei.gmxhome.de/eclipse (301) migrated to:  
  http://andrei.gmxhome.de/eclipse/ ([https](https://andrei.gmxhome.de/eclipse) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://dist.springsource.com/release/TOOLS/update/e4.5 (403) migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e4.5 ([https](https://dist.springsource.com/release/TOOLS/update/e4.5) result 403).
* http://www.eclipse.org/oomph/predicates/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/predicates/1.0 ([https](https://www.eclipse.org/oomph/predicates/1.0) result 404).
* http://www.eclipse.org/oomph/setup/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/1.0 ([https](https://www.eclipse.org/oomph/setup/1.0) result 404).
* http://www.eclipse.org/oomph/setup/jdt/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/jdt/1.0 ([https](https://www.eclipse.org/oomph/setup/jdt/1.0) result 404).
* http://www.eclipse.org/oomph/setup/maven/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/maven/1.0 ([https](https://www.eclipse.org/oomph/setup/maven/1.0) result 404).
* http://www.eclipse.org/oomph/setup/p2/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/p2/1.0 ([https](https://www.eclipse.org/oomph/setup/p2/1.0) result 404).
* http://www.eclipse.org/oomph/setup/workingsets/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/workingsets/1.0 ([https](https://www.eclipse.org/oomph/setup/workingsets/1.0) result 404).
* http://www.eclipse.org/oomph/workingsets/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/workingsets/1.0 ([https](https://www.eclipse.org/oomph/workingsets/1.0) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://download.eclipse.org/egit/github/updates/ migrated to:  
  https://download.eclipse.org/egit/github/updates/ ([https](https://download.eclipse.org/egit/github/updates/) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore) result 200).
* http://download.eclipse.org/releases/mars migrated to:  
  https://download.eclipse.org/releases/mars ([https](https://download.eclipse.org/releases/mars) result 301).
* http://download.eclipse.org/technology/epp/packages/mars/R migrated to:  
  https://download.eclipse.org/technology/epp/packages/mars/R ([https](https://download.eclipse.org/technology/epp/packages/mars/R) result 301).
* http://www.omg.org/XMI migrated to:  
  https://www.omg.org/XMI ([https](https://www.omg.org/XMI) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/2001/XMLSchema-instance