### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,8 +14,8 @@ unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 == Using GitHub issues
 We use GitHub issues to track bugs and enhancements. If you have a general usage question
-please ask on http://stackoverflow.com[Stack Overflow]. The Spring Boot team and the
-broader community monitor the http://stackoverflow.com/tags/spring-boot[`spring-boot`]
+please ask on https://stackoverflow.com[Stack Overflow]. The Spring Boot team and the
+broader community monitor the https://stackoverflow.com/tags/spring-boot[`spring-boot`]
 tag.
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as much
@@ -43,7 +43,7 @@ added after the original pull request but before a merge.
   the '`Importing into eclipse`' instructions below you should get project specific
   formatting automatically. You can also import formatter settings using the
   `eclipse-code-formatter.xml` file from the `eclipse` folder. If using IntelliJ IDEA, you
-  can use the http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter Plugin]
+  can use the https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter Plugin]
   to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -56,7 +56,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where `XXXX` is the issue number).
 
@@ -65,15 +65,15 @@ added after the original pull request but before a merge.
 == Working with the code
 If you don't have an IDE preference we would recommend that you use
 https://spring.io/tools/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[M2Eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[M2Eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 
 
 === Building from source
 To build the source you will need to install
-http://maven.apache.org/run-maven/index.html[Apache Maven] v3.2.3 or above and JDK 1.8.
+https://maven.apache.org/run-maven/index.html[Apache Maven] v3.2.3 or above and JDK 1.8.
 
 
 
@@ -153,7 +153,7 @@ Spring Boot includes a `.setup` files which can be used with the Eclipse Install
 provision a new environment. To use the installer:
 
 * Download and run the latest Eclipse Installer from
-  http://www.eclipse.org/downloads/[eclipse.org/downloads/].
+  https://www.eclipse.org/downloads/[eclipse.org/downloads/].
 * Switch to "Advanced Mode" using the drop down menu on the right.
 * Select "`Eclipse IDE for Java Developers`" under "`Eclipse.org`" as the product to
   install and click "`next`".
@@ -175,7 +175,7 @@ easier to navigate.
 
 ==== Manual installation with m2eclipse
 If you prefer to install Eclipse yourself we recommend that you use the
-http://eclipse.org/m2e/[M2Eclipse] eclipse plugin. If you don't already have m2eclipse
+https://eclipse.org/m2e/[M2Eclipse] eclipse plugin. If you don't already have m2eclipse
 installed it is available from the "Eclipse marketplace".
 
 Spring Boot includes project specific source formatting settings, in order to have these

--- a/samples/spring-boot-sample-web-secure-github/src/main/resources/static/index.html
+++ b/samples/spring-boot-sample-web-secure-github/src/main/resources/static/index.html
@@ -8,7 +8,7 @@
 	<div class="container">
 		<div class="navbar">
 			<div class="navbar-inner">
-				<a class="brand" href="http://spring.io"> Spring </a>
+				<a class="brand" href="https://spring.io"> Spring </a>
 				<ul class="nav">
 					<li><a href="/"> Home </a></li>
 				</ul>

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/OAuth2AutoConfigurationTests.java
@@ -399,7 +399,7 @@ public class OAuth2AutoConfigurationTests {
 			throws Exception {
 		this.context = new AnnotationConfigServletWebServerApplicationContext();
 		TestPropertyValues.of(
-				"security.oauth2.resource.jwk.key-set-uri:http://my-auth-server/token_keys")
+				"security.oauth2.resource.jwk.key-set-uri:https://my-auth-server/token_keys")
 				.applyTo(this.context);
 		this.context.register(ResourceServerConfiguration.class,
 				MinimalSecureWebApplication.class);

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/MultipleResourceServerConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/MultipleResourceServerConfigurationTests.java
@@ -55,7 +55,7 @@ public class MultipleResourceServerConfigurationTests {
 	public void orderIsUnchangedWhenThereAreMultipleResourceServerConfigurations() {
 		this.context = new AnnotationConfigWebApplicationContext();
 		this.context.register(DoubleResourceConfiguration.class);
-		TestPropertyValues.of("security.oauth2.resource.tokenInfoUri:http://example.com",
+		TestPropertyValues.of("security.oauth2.resource.tokenInfoUri:https://example.com",
 				"security.oauth2.client.clientId=acme").applyTo(this.context);
 		this.context.refresh();
 		assertThat(this.context

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerPropertiesTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerPropertiesTests.java
@@ -56,7 +56,7 @@ public class ResourceServerPropertiesTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void json() throws Exception {
-		this.properties.getJwt().setKeyUri("http://example.com/token_key");
+		this.properties.getJwt().setKeyUri("https://example.com/token_key");
 		ObjectMapper mapper = new ObjectMapper();
 		String json = mapper.writeValueAsString(this.properties);
 		Map<String, Object> value = mapper.readValue(json, Map.class);
@@ -74,8 +74,8 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void validateWhenBothJwtAndJwkKeyUrisPresentShouldFail() throws Exception {
-		this.properties.getJwk().setKeySetUri("http://my-auth-server/token_keys");
-		this.properties.getJwt().setKeyUri("http://my-auth-server/token_key");
+		this.properties.getJwk().setKeySetUri("https://my-auth-server/token_keys");
+		this.properties.getJwt().setKeyUri("https://my-auth-server/token_key");
 		setListableBeanFactory();
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expect(getMatcher("Only one of jwt.keyUri (or jwt.keyValue) "
@@ -86,7 +86,7 @@ public class ResourceServerPropertiesTests {
 	@Test
 	public void validateWhenBothJwtKeyValueAndJwkKeyUriPresentShouldFail()
 			throws Exception {
-		this.properties.getJwk().setKeySetUri("http://my-auth-server/token_keys");
+		this.properties.getJwk().setKeySetUri("https://my-auth-server/token_keys");
 		this.properties.getJwt().setKeyValue("my-key");
 		setListableBeanFactory();
 		this.thrown.expect(IllegalStateException.class);
@@ -97,7 +97,7 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void validateWhenJwkKeySetUriProvidedShouldSucceed() throws Exception {
-		this.properties.getJwk().setKeySetUri("http://my-auth-server/token_keys");
+		this.properties.getJwk().setKeySetUri("https://my-auth-server/token_keys");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);
@@ -115,7 +115,7 @@ public class ResourceServerPropertiesTests {
 	public void validateWhenKeysUriOrValuePresentAndUserInfoAbsentShouldNotFail()
 			throws Exception {
 		this.properties = new ResourceServerProperties("client", "");
-		this.properties.getJwk().setKeySetUri("http://my-auth-server/token_keys");
+		this.properties.getJwk().setKeySetUri("https://my-auth-server/token_keys");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);
@@ -133,7 +133,7 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void validateWhenTokenUriConfiguredShouldNotFail() throws Exception {
-		this.properties.setTokenInfoUri("http://my-auth-server/userinfo");
+		this.properties.setTokenInfoUri("https://my-auth-server/userinfo");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);
@@ -141,7 +141,7 @@ public class ResourceServerPropertiesTests {
 
 	@Test
 	public void validateWhenUserInfoUriConfiguredShouldNotFail() throws Exception {
-		this.properties.setUserInfoUri("http://my-auth-server/userinfo");
+		this.properties.setUserInfoUri("https://my-auth-server/userinfo");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);
@@ -151,8 +151,8 @@ public class ResourceServerPropertiesTests {
 	public void validateWhenTokenUriPreferredAndClientSecretAbsentShouldFail()
 			throws Exception {
 		this.properties = new ResourceServerProperties("client", "");
-		this.properties.setTokenInfoUri("http://my-auth-server/check_token");
-		this.properties.setUserInfoUri("http://my-auth-server/userinfo");
+		this.properties.setTokenInfoUri("https://my-auth-server/check_token");
+		this.properties.setUserInfoUri("https://my-auth-server/userinfo");
 		setListableBeanFactory();
 		this.thrown.expect(IllegalStateException.class);
 		this.thrown.expect(getMatcher("Missing client secret", "clientSecret"));
@@ -163,7 +163,7 @@ public class ResourceServerPropertiesTests {
 	public void validateWhenTokenUriAbsentAndClientSecretAbsentShouldNotFail()
 			throws Exception {
 		this.properties = new ResourceServerProperties("client", "");
-		this.properties.setUserInfoUri("http://my-auth-server/userinfo");
+		this.properties.setUserInfoUri("https://my-auth-server/userinfo");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);
@@ -174,8 +174,8 @@ public class ResourceServerPropertiesTests {
 			throws Exception {
 		this.properties = new ResourceServerProperties("client", "");
 		this.properties.setPreferTokenInfo(false);
-		this.properties.setTokenInfoUri("http://my-auth-server/check_token");
-		this.properties.setUserInfoUri("http://my-auth-server/userinfo");
+		this.properties.setTokenInfoUri("https://my-auth-server/check_token");
+		this.properties.setUserInfoUri("https://my-auth-server/userinfo");
 		setListableBeanFactory();
 		this.properties.validate();
 		verifyZeroInteractions(this.errors);

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfigurationTests.java
@@ -95,7 +95,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 	@Test
 	public void useRemoteTokenServices() {
-		TestPropertyValues.of("security.oauth2.resource.tokenInfoUri:http://example.com")
+		TestPropertyValues.of("security.oauth2.resource.tokenInfoUri:https://example.com")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.NONE).run();
@@ -105,7 +105,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 	@Test
 	public void switchToUserInfo() {
-		TestPropertyValues.of("security.oauth2.resource.userInfoUri:http://example.com")
+		TestPropertyValues.of("security.oauth2.resource.userInfoUri:https://example.com")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.NONE).run();
@@ -116,7 +116,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 	@Test
 	public void userInfoWithAuthorities() {
-		TestPropertyValues.of("security.oauth2.resource.userInfoUri:http://example.com")
+		TestPropertyValues.of("security.oauth2.resource.userInfoUri:https://example.com")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(AuthoritiesConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.NONE).run();
@@ -129,7 +129,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 	@Test
 	public void userInfoWithPrincipal() {
-		TestPropertyValues.of("security.oauth2.resource.userInfoUri:http://example.com")
+		TestPropertyValues.of("security.oauth2.resource.userInfoUri:https://example.com")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(PrincipalConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.NONE).run();
@@ -143,7 +143,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void userInfoWithClient() {
 		TestPropertyValues.of("security.oauth2.client.client-id=acme",
-				"security.oauth2.resource.userInfoUri:http://example.com",
+				"security.oauth2.resource.userInfoUri:https://example.com",
 				"server.port=-1", "debug=true").applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceNoClientConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.SERVLET).run();
@@ -155,8 +155,8 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void preferUserInfo() {
 		TestPropertyValues
-				.of("security.oauth2.resource.userInfoUri:http://example.com",
-						"security.oauth2.resource.tokenInfoUri:http://example.com",
+				.of("security.oauth2.resource.userInfoUri:https://example.com",
+						"security.oauth2.resource.tokenInfoUri:https://example.com",
 						"security.oauth2.resource.preferTokenInfo:false")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceConfiguration.class)
@@ -169,8 +169,8 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void userInfoWithCustomizer() {
 		TestPropertyValues
-				.of("security.oauth2.resource.userInfoUri:http://example.com",
-						"security.oauth2.resource.tokenInfoUri:http://example.com",
+				.of("security.oauth2.resource.userInfoUri:https://example.com",
+						"security.oauth2.resource.tokenInfoUri:https://example.com",
 						"security.oauth2.resource.preferTokenInfo:false")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceConfiguration.class,
@@ -206,7 +206,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void jwkConfiguration() throws Exception {
 		TestPropertyValues.of(
-				"security.oauth2.resource.jwk.key-set-uri=http://my-auth-server/token_keys")
+				"security.oauth2.resource.jwk.key-set-uri=https://my-auth-server/token_keys")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(ResourceConfiguration.class)
 				.environment(this.environment).web(WebApplicationType.NONE).run();
@@ -219,7 +219,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void springSocialUserInfo() {
 		TestPropertyValues
-				.of("security.oauth2.resource.userInfoUri:http://example.com",
+				.of("security.oauth2.resource.userInfoUri:https://example.com",
 						"spring.social.facebook.app-id=foo",
 						"spring.social.facebook.app-secret=bar")
 				.applyTo(this.environment);
@@ -235,7 +235,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 	@Test
 	public void customUserInfoRestTemplateFactory() {
-		TestPropertyValues.of("security.oauth2.resource.userInfoUri:http://example.com")
+		TestPropertyValues.of("security.oauth2.resource.userInfoUri:https://example.com")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(
 				CustomUserInfoRestTemplateFactory.class, ResourceConfiguration.class)
@@ -260,7 +260,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 	@Test
 	public void jwkTokenStoreShouldBeConditionalOnMissingBean() throws Exception {
 		TestPropertyValues.of(
-				"security.oauth2.resource.jwk.key-set-uri=http://my-auth-server/token_keys")
+				"security.oauth2.resource.jwk.key-set-uri=https://my-auth-server/token_keys")
 				.applyTo(this.environment);
 		this.context = new SpringApplicationBuilder(JwkTokenStoreConfiguration.class,
 				ResourceConfiguration.class).environment(this.environment)
@@ -454,7 +454,7 @@ public class ResourceServerTokenServicesConfigurationTests {
 
 		@Bean
 		public TokenStore tokenStore() {
-			return new JwkTokenStore("http://my.key-set.uri");
+			return new JwkTokenStore("https://my.key-set.uri");
 		}
 
 	}

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServicesRefreshTokenTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServicesRefreshTokenTests.java
@@ -60,7 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
-		"security.oauth2.resource.userInfoUri:http://example.com",
+		"security.oauth2.resource.userInfoUri:https://example.com",
 		"security.oauth2.client.clientId=foo" })
 @DirtiesContext
 public class UserInfoTokenServicesRefreshTokenTests {

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServicesTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/UserInfoTokenServicesTests.java
@@ -51,7 +51,7 @@ public class UserInfoTokenServicesTests {
 	public ExpectedException expected = ExpectedException.none();
 
 	private UserInfoTokenServices services = new UserInfoTokenServices(
-			"http://example.com", "foo");
+			"https://example.com", "foo");
 
 	private BaseOAuth2ProtectedResourceDetails resource = new BaseOAuth2ProtectedResourceDetails();
 

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/BasicOAuth2SsoConfigurationTests.java
@@ -50,8 +50,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @TestPropertySource(properties = { "security.oauth2.client.clientId=client",
 		"security.oauth2.client.clientSecret=secret",
-		"security.oauth2.client.userAuthorizationUri=http://example.com/oauth/authorize",
-		"security.oauth2.client.accessTokenUri=http://example.com/oauth/token",
+		"security.oauth2.client.userAuthorizationUri=https://example.com/oauth/authorize",
+		"security.oauth2.client.accessTokenUri=https://example.com/oauth/token",
 		"security.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class BasicOAuth2SsoConfigurationTests {
 

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomOAuth2SsoConfigurationTests.java
@@ -55,8 +55,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @TestPropertySource(properties = { "security.oauth2.client.clientId=client",
 		"security.oauth2.client.clientSecret=secret",
-		"security.oauth2.client.authorizationUri=http://example.com/oauth/authorize",
-		"security.oauth2.client.tokenUri=http://example.com/oauth/token",
+		"security.oauth2.client.authorizationUri=https://example.com/oauth/authorize",
+		"security.oauth2.client.tokenUri=https://example.com/oauth/token",
 		"security.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class CustomOAuth2SsoConfigurationTests {
 

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomOAuth2SsoWithAuthenticationEntryPointConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomOAuth2SsoWithAuthenticationEntryPointConfigurationTests.java
@@ -56,8 +56,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @TestPropertySource(properties = { "security.oauth2.client.clientId=client",
 		"security.oauth2.client.clientSecret=secret",
-		"security.oauth2.client.authorizationUri=http://example.com/oauth/authorize",
-		"security.oauth2.client.tokenUri=http://example.com/oauth/token",
+		"security.oauth2.client.authorizationUri=https://example.com/oauth/authorize",
+		"security.oauth2.client.tokenUri=https://example.com/oauth/token",
 		"security.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class CustomOAuth2SsoWithAuthenticationEntryPointConfigurationTests {
 

--- a/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomRestTemplateBasicOAuth2SsoConfigurationTests.java
+++ b/spring-security-oauth2-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/sso/CustomRestTemplateBasicOAuth2SsoConfigurationTests.java
@@ -48,8 +48,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @SpringBootTest
 @TestPropertySource(properties = { "security.oauth2.client.clientId=client",
 		"security.oauth2.client.clientSecret=secret",
-		"security.oauth2.client.userAuthorizationUri=http://example.com/oauth/authorize",
-		"security.oauth2.client.accessTokenUri=http://example.com/oauth/token",
+		"security.oauth2.client.userAuthorizationUri=https://example.com/oauth/authorize",
+		"security.oauth2.client.accessTokenUri=https://example.com/oauth/token",
 		"security.oauth2.resource.jwt.keyValue=SSSSHHH" })
 public class CustomRestTemplateBasicOAuth2SsoConfigurationTests {
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.eclipse.org/downloads/ (302) with 1 occurrences migrated to:  
  https://www.eclipse.org/downloads/ ([https](https://www.eclipse.org/downloads/) result ReadTimeoutException).
* [ ] http://my-auth-server/check_token (UnknownHostException) with 2 occurrences migrated to:  
  https://my-auth-server/check_token ([https](https://my-auth-server/check_token) result UnknownHostException).
* [ ] http://my-auth-server/token_key (UnknownHostException) with 1 occurrences migrated to:  
  https://my-auth-server/token_key ([https](https://my-auth-server/token_key) result UnknownHostException).
* [ ] http://my-auth-server/token_keys (UnknownHostException) with 7 occurrences migrated to:  
  https://my-auth-server/token_keys ([https](https://my-auth-server/token_keys) result UnknownHostException).
* [ ] http://my-auth-server/userinfo (UnknownHostException) with 5 occurrences migrated to:  
  https://my-auth-server/userinfo ([https](https://my-auth-server/userinfo) result UnknownHostException).
* [ ] http://my.key-set.uri (UnknownHostException) with 1 occurrences migrated to:  
  https://my.key-set.uri ([https](https://my.key-set.uri) result UnknownHostException).
* [ ] http://example.com/oauth/authorize (404) with 4 occurrences migrated to:  
  https://example.com/oauth/authorize ([https](https://example.com/oauth/authorize) result 404).
* [ ] http://example.com/oauth/token (404) with 4 occurrences migrated to:  
  https://example.com/oauth/token ([https](https://example.com/oauth/token) result 404).
* [ ] http://example.com/token_key (404) with 1 occurrences migrated to:  
  https://example.com/token_key ([https](https://example.com/token_key) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com with 14 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://maven.apache.org/run-maven/index.html with 1 occurrences migrated to:  
  https://maven.apache.org/run-maven/index.html ([https](https://maven.apache.org/run-maven/index.html) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-boot with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-boot ([https](https://stackoverflow.com/tags/spring-boot) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://localhost/login with 2 occurrences
* http://localhost:12345/banana with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8080/flights/1 with 1 occurrences
* http://localhost:8080/flights/2 with 1 occurrences
* http://localhost:8080/login with 1 occurrences
* http://localhost:8080/oauth/authorize?grant_type=authorization_code&response_type=code&client_id=first-client&state=1234 with 1 occurrences
* http://localhost:8080/user with 2 occurrences
* http://localhost:8081/oauth/login/client-app with 2 occurrences